### PR TITLE
README.md JDK 버전 변경 참고 URL의 ESC문자 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### 버전 정보
 - Spring Boot; 3.3.5
 - JDK(Java Development Kit); Java 21 이상
-    - Intellij에서 JDK 버전 변경하는 방법(참고 URL: https://inpa.tistory.com/entry/IntelliJ-%F0%9F%92%BD-%EC%9E%90%EB%B0%94-JDK-%EB%B2%84%EC%A0%84-%EB%B3%80%EA%B2%BD-%EB%B0%A9%EB%B2%95)
+    - Intellij에서 JDK 버전 변경하는 방법(참고 URL: https://inpa.tistory.com/entry/IntelliJ-%F0%9F%92%BD-%EC%9E%90%EB%B0%94-JDK-%EB%B2%84%EC%A0%84-%EB%B3%80%EA%B2%BD-%EB%B0%A9%EB%B2%95)
 ### 필수 설치 패키지
 - Docker Desktop
 


### PR DESCRIPTION
JDK 버전 변경 참고 URL의 제일 뒤에 ESC 문자가 포함되어있습니다.
환경에따라 다르지만 ESC 문자가 링크에 포함되어 제대로 참조되지 않을 수 있어서 해당 문자를 제거했습니다.

![image](https://github.com/user-attachments/assets/06cfb750-549d-47d2-9e77-1562e1692d05)
